### PR TITLE
rblibtorrent: bump to git HEAD (#412)

### DIFF
--- a/libs/rblibtorrent/Makefile
+++ b/libs/rblibtorrent/Makefile
@@ -1,15 +1,15 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rblibtorrent
-PKG_VERSION:=1.2.15
-PKG_RELEASE=2
+PKG_VERSION:=1.2.16
+PKG_RELEASE=1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/arvidn/libtorrent.git
 PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
-PKG_SOURCE_VERSION:=1b25eb5584db5f335167e6f8beda1ae280f28445
+PKG_SOURCE_VERSION:=239500acf2bc60dcb91330bf3c21b939d9f603af
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_MIRROR_HASH:=d0cb50a9dd6cc740dfa8f7a93be2c614a40165246c0454ae6f147cda7aa3f994
+PKG_MIRROR_HASH:=65de484e2c54767b029f38bead4e802337de13529fac8fa47e26b1a7474a2ee3
 
 PKG_LICENSE:=BSD
 PKG_LICENSE_FILES:=COPYING
@@ -25,7 +25,7 @@ define Package/rblibtorrent
   CATEGORY:=Libraries
   TITLE:=Rasterbar BitTorrent library
   URL:=https://www.libtorrent.org/
-  DEPENDS:=+libgcc +libstdcpp +libopenssl +boost +boost-system +boost-chrono +boost-random
+  DEPENDS:=+libgcc +libstdcpp +libopenssl +boost +boost-system +boost-chrono +boost-random +libatomic
   MAINTAINER:=Arvid Norberg <arvid@libtorrent.org>
 endef
 


### PR DESCRIPTION
* rblibtorrent: Add libstomic deps
Fix:
Package rblibtorrent is missing dependencies for the following libraries:
libatomic.so.1

* rblibtorrent: bump to git HEAD

Co-authored-by: breakings <breakingstop@gmail.com>

Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
