### PR TITLE
ruby: fix build with LibreSSL over v3.5 (#486)

### DIFF
--- a/lang/ruby/patches/001-fix-build-with-libressl-3.5.patch
+++ b/lang/ruby/patches/001-fix-build-with-libressl-3.5.patch
@@ -1,0 +1,20 @@
+From e25fb0d0d86da5a9398ebdc9216b2ea89f80fa3d Mon Sep 17 00:00:00 2001
+From: Jeremy Evans <code@jeremyevans.net>
+Date: Fri, 25 Mar 2022 13:11:31 -0700
+Subject: [PATCH] Fix build with LibreSSL 3.5
+
+---
+ ext/openssl/ossl_pkey.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/ext/openssl/ossl_pkey.c
++++ b/ext/openssl/ossl_pkey.c
+@@ -670,7 +670,7 @@ ossl_pkey_export_traditional(int argc, V
+ 	}
+     }
+     else {
+-#if OPENSSL_VERSION_NUMBER >= 0x10100000 && !defined(LIBRESSL_VERSION_NUMBER)
++#if OSSL_OPENSSL_PREREQ(1, 1, 0) || OSSL_LIBRESSL_PREREQ(3, 5, 0)
+ 	if (!PEM_write_bio_PrivateKey_traditional(bio, pkey, enc, NULL, 0,
+ 						  ossl_pem_passwd_cb,
+ 						  (void *)pass)) {

--- a/lang/ruby/patches/002-fix-operator-precedence.patch
+++ b/lang/ruby/patches/002-fix-operator-precedence.patch
@@ -1,0 +1,28 @@
+From b02815271fcc295cb8b07ef740684b88a10f2760 Mon Sep 17 00:00:00 2001
+From: Jeremy Evans <code@jeremyevans.net>
+Date: Fri, 25 Mar 2022 13:39:45 -0700
+Subject: [PATCH] Fix operator precedence in OSSL_OPENSSL_PREREQ and
+ OSSL_LIBRESSL_PREREQ
+
+---
+ ext/openssl/ossl.h | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+--- a/ext/openssl/ossl.h
++++ b/ext/openssl/ossl.h
+@@ -43,13 +43,13 @@
+ #ifndef LIBRESSL_VERSION_NUMBER
+ # define OSSL_IS_LIBRESSL 0
+ # define OSSL_OPENSSL_PREREQ(maj, min, pat) \
+-      (OPENSSL_VERSION_NUMBER >= (maj << 28) | (min << 20) | (pat << 12))
++      (OPENSSL_VERSION_NUMBER >= ((maj << 28) | (min << 20) | (pat << 12)))
+ # define OSSL_LIBRESSL_PREREQ(maj, min, pat) 0
+ #else
+ # define OSSL_IS_LIBRESSL 1
+ # define OSSL_OPENSSL_PREREQ(maj, min, pat) 0
+ # define OSSL_LIBRESSL_PREREQ(maj, min, pat) \
+-      (LIBRESSL_VERSION_NUMBER >= (maj << 28) | (min << 20) | (pat << 12))
++      (LIBRESSL_VERSION_NUMBER >= ((maj << 28) | (min << 20) | (pat << 12)))
+ #endif
+ 
+ #if !defined(OPENSSL_NO_ENGINE) && !OSSL_OPENSSL_PREREQ(3, 0, 0)


### PR DESCRIPTION
LibreSSL 3.5 and later provide and need to use
PEM_write_bio_PrivateKey_traditional()

upstream commit:
https://github.com/ruby/openssl/commit/e25fb0d0d86da5a9398ebdc9216b2ea89f80fa3d
https://github.com/ruby/openssl/commit/b02815271fcc295cb8b07ef740684b88a10f2760

Signed-off-by: ZiMing Mo <msylgj@immortalwrt.org>

Co-authored-by: ZiMing Mo <msylgj@immortalwrt.org>

Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
